### PR TITLE
Fill coupon order linktable

### DIFF
--- a/domain/src/main/java/me/fontys/semester4/utility/ProcessCouponsProc.java
+++ b/domain/src/main/java/me/fontys/semester4/utility/ProcessCouponsProc.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class ProcessCouponsProc extends CustomSqlExecutor
 {
 
-    @Value("classpath:processCoupons.sql")
+    @Value("classpath:processCoupon.sql")
     private Resource processCouponsProc;
 
     private Date sessionDate;

--- a/domain/src/main/resources/processCoupon.sql
+++ b/domain/src/main/resources/processCoupon.sql
@@ -18,152 +18,154 @@ declare
     workingCouponId          integer        := null;
 
 begin
-            if(originalCouponcode = '') then
-                return;
+    if(originalCouponcode = '') then
+        return;
+    end if;
+    -- check if coupon action exist
+    if (originalCouponcode ~ '^.+\% korting op je bestelling$') then
+
+        percentageAct = (REGEXP_MATCHES(originalCouponcode, '([0-9]+)\%'))[1];
+        if ((select count(*)
+             from coupon_actions
+             where d_percentage = percentageAct) = 0)
+        then
+            insert into coupon_actions (d_percentage)
+            values (percentageAct)
+            returning actionid into actionIdToUse;
+            newActions = newActions + 1;
+            call createLogEntry(format('created coupon action percentage %L%% reduction id:%L',
+                                       percentageAct, actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
+        else
+            actionIdToUse = (select ca.actionid
+                             from coupon_actions ca
+                             where ca.d_percentage = percentageAct
+                               and ca.each_x_free is null
+                               and ca.fixedprice is null
+                               and ca.freeship is null);
+        end if;
+    end if;
+
+    -- check if coupon action exist
+    if (originalCouponcode ~ '^[1-9]+e pizza gratis bij .+$') then
+
+        eachxFreeAct = (REGEXP_MATCHES(originalCouponcode, '^([1-9]+)e'))[1];
+        if ((select count(*)
+             from coupon_actions ca
+             where ca.each_x_free = eachxFreeAct
+               and ca.d_percentage is null
+               and ca.fixedprice is null
+               and ca.freeship is null) = 0)
+        then
+            insert into coupon_actions (each_x_free)
+            values (eachxFreeAct)
+            returning actionid into actionIdToUse;
+            newActions = newActions + 1;
+
+            call createLogEntry(format('created coupon action each %L free id:%L',
+                                       eachxFreeAct, actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
+        else
+            actionIdToUse = (select ca.actionid
+                             from coupon_actions ca
+                             where ca.each_x_free = eachxFreeAct
+                               and ca.d_percentage is null
+                               and ca.fixedprice is null
+                               and ca.freeship is null);
+        end if;
+    end if;
+
+    -- check if coupon action exist
+    if (originalCouponcode ~ '.+ [0-9\,\-]+ Korting op.+$') then
+        fixedpricePart = (REGEXP_MATCHES(originalCouponcode, '.+ ([0-9\,\-]+) Korting'))[1];
+        call createLogEntry(format('extracted coupon action fixedprice %L', fixedpricePart)::varchar(255),
+                            logsessiontime,'INFO','process_coupons procedure');
+        fixedpriceAct = TO_NUMBER(replace(replace(fixedpricePart, ',', '.'), '-', '00'), '999D9S');
+
+        if ((select count(*)
+             from coupon_actions ca
+             where ca.fixedprice = fixedpriceAct
+               and ca.d_percentage is null
+               and ca.each_x_free is null
+               and ca.freeship is null) = 0)
+        then
+            insert into coupon_actions (fixedprice)
+            values (fixedpriceAct)
+            returning actionid into actionIdToUse;
+            newActions = newActions + 1;
+            call createLogEntry(format('created coupon action reduce price by %L id:%L', fixedpriceAct,
+                                       actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
+        else
+            actionIdToUse = (select ca.actionid
+                             from coupon_actions ca
+                             where ca.fixedprice = fixedpriceAct
+                               and ca.d_percentage is null
+                               and ca.each_x_free is null
+                               and ca.freeship is null);
+        end if;
+    end if;
+
+    -- check if coupon condition exists
+    if (originalCouponcode ~ '(afhalen|bezorgen|vanaf)') then
+        takeAwayPart = (REGEXP_MATCHES(originalCouponcode, '(afhalen|bezorgen)'))[1];
+        if (takeAwayPart = 'afhalen')
+        then
+            takeAwayConditionToUse = true;
+        else
+            if (takeAwayPart = 'bezorgen') then
+                takeAwayConditionToUse = false;
+            else
+                takeAwayConditionToUse = null;
             end if;
-            -- check if coupon action exist
-            if (originalCouponcode ~ '^.+\% korting op je bestelling$') then
-
-                percentageAct = (REGEXP_MATCHES(originalCouponcode, '([0-9]+)\%'))[1];
-                if ((select count(*)
-                     from coupon_actions
-                     where d_percentage = percentageAct) = 0)
-                then
-                    insert into coupon_actions (d_percentage)
-                    values (percentageAct)
-                    returning actionid into actionIdToUse;
-                    newActions = newActions + 1;
-                    call createLogEntry(format('created coupon action percentage %L%% reduction id:%L',
-                                               percentageAct, actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
-                else
-                    actionIdToUse = (select ca.actionid
-                                     from coupon_actions ca
-                                     where ca.d_percentage = percentageAct
-                                       and ca.each_x_free is null
-                                       and ca.fixedprice is null
-                                       and ca.freeship is null).actionid;
-                end if;
-            end if;
-
-            -- check if coupon action exist
-            if (originalCouponcode ~ '^[1-9]+e pizza gratis bij .+$') then
-
-                eachxFreeAct = (REGEXP_MATCHES(originalCouponcode, '^([1-9]+)e'))[1];
-                if ((select count(*)
-                     from coupon_actions ca
-                     where ca.each_x_free = eachxFreeAct
-                       and ca.d_percentage is null
-                       and ca.fixedprice is null
-                       and ca.freeship is null) = 0)
-                then
-                    insert into coupon_actions (each_x_free)
-                    values (eachxFreeAct)
-                    returning actionid into actionIdToUse;
-                    newActions = newActions + 1;
-
-                    call createLogEntry(format('created coupon action each %L free id:%L',
-                                               eachxFreeAct, actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
-                else
-                    actionIdToUse = (select ca.actionid
-                                     from coupon_actions ca
-                                     where ca.each_x_free = eachxFreeAct
-                                       and ca.d_percentage is null
-                                       and ca.fixedprice is null
-                                       and ca.freeship is null).actionid;
-                end if;
-            end if;
-
-            -- check if coupon action exist
-            if (originalCouponcode ~ '.+ [0-9\,\-]+ Korting op.+$') then
-                fixedpricePart = (REGEXP_MATCHES(originalCouponcode, '.+ ([0-9\,\-]+) Korting'))[1];
-                call createLogEntry(format('extracted coupon action fixedprice %L', fixedpricePart)::varchar(255),
-                                    logsessiontime,'INFO','process_coupons procedure');
-                fixedpriceAct = TO_NUMBER(replace(replace(fixedpricePart, ',', '.'), '-', '00'), '999D9S');
-
-                if ((select count(*)
-                     from coupon_actions ca
-                     where ca.fixedprice = fixedpriceAct
-                       and ca.d_percentage is null
-                       and ca.each_x_free is null
-                       and ca.freeship is null) = 0)
-                then
-                    insert into coupon_actions (fixedprice)
-                    values (fixedpriceAct)
-                    returning actionid into actionIdToUse;
-                    newActions = newActions + 1;
-                    call createLogEntry(format('created coupon action reduce price by %L id:%L', fixedpriceAct,
-                                               actionIdToUse), logsessiontime,'INFO','process_coupons procedure');
-                else
-                    actionIdToUse = (select ca.actionid
-                                     from coupon_actions ca
-                                     where ca.fixedprice = fixedpriceAct
-                                       and ca.d_percentage is null
-                                       and ca.each_x_free is null
-                                       and ca.freeship is null).actionid;
-                end if;
-            end if;
-
-            -- check if coupon condition exists
-            if (originalCouponcode ~ '(afhalen|bezorgen|vanaf)') then
-                takeAwayPart = (REGEXP_MATCHES(originalCouponcode, '(afhalen|bezorgen)'))[1];
-                if (takeAwayPart = 'afhalen')
-                then
-                    takeAwayConditionToUse = true;
-                else
-                    if (takeAwayPart = 'bezorgen') then
-                        takeAwayConditionToUse = false;
-                    else
-                        takeAwayConditionToUse = null;
-                    end if;
-                end if;
-                if (originalCouponcode ~ '(vanaf)') then
-                    minPricePart = (REGEXP_MATCHES(originalCouponcode, 'vanaf . ([0-9\,\-]+)'))[1];
-                    call createLogEntry(format('extracted coupon condition minimum price %L', minPricePart),
-                                        logsessiontime,'INFO','process_coupons procedure');
-                    minPrice = TO_NUMBER(replace(replace(minPricePart, ',', '.'), '-', '00'), '999D9S');
-                else
-                    minPrice = null;
-                end if;
-                if ((select count(*)
-                     from coupon_conditions cc
-                     where cc.takeaway = takeAwayConditionToUse
-                       and cc.min_price = minPrice
-                       and cc.min_quantity is null) = 0)
-                then
-                    insert into coupon_conditions (takeaway, min_price)
-                    values (takeAwayConditionToUse, minPrice)
-                    returning conditionid into takeAwayConditionIdToUse;
-                    newActions = newActions + 1;
-                    call createLogEntry(format('created coupon condition takeaway:"%L" minprice:"%L" id:%L',
-                                               takeAwayConditionToUse, minPrice, takeAwayConditionIdToUse),
-                                        logsessiontime,'INFO','process_coupons procedure');
-                else
-                    takeAwayConditionIdToUse = (select cc.conditionid
-                                                from coupon_conditions cc
-                                                where cc.takeaway = takeAwayConditionToUse
-                                                  and cc.min_price = minPrice
-                                                  and cc.min_quantity is null).conditionid;
-                end if;
-            end if;
-            workingCouponId = (select c.couponid
-                                        from coupon c
-                                        where c.couponcode = originalCouponcode
-                                          and c.action = actionIdToUse
-                                          and c.condition = takeAwayConditionIdToUse).couponid;
-            if(workingCouponId is null) then
-                --create new coupon and associate with correct action and condition (if applicable)
-                insert into coupon (couponcode, "action", "condition")
-                values (originalCouponcode, actionIdToUse, takeAwayConditionIdToUse)
-                returning couponid into workingCouponId;
-            end if;
-
-            -- create link table entry order - coupon
-            insert into coupon_order (orderid,couponid)
-            values(orderIdToLink,workingCouponId);
-
-            call createLogEntry(format('created coupon with code "%L" actionid:%L conditionid:"%L" couponid:%L',
-                                       originalCouponcode, actionIdToUse, takeAwayConditionIdToUse, workingCouponId),
+        end if;
+        if (originalCouponcode ~ '(vanaf)') then
+            minPricePart = (REGEXP_MATCHES(originalCouponcode, 'vanaf . ([0-9\,\-]+)'))[1];
+            call createLogEntry(format('extracted coupon condition minimum price %L', minPricePart),
                                 logsessiontime,'INFO','process_coupons procedure');
+            minPrice = TO_NUMBER(replace(replace(minPricePart, ',', '.'), '-', '00'), '999D9S');
+        else
+            minPrice = null;
+        end if;
+        if ((select count(*)
+             from coupon_conditions cc
+             where cc.takeaway = takeAwayConditionToUse
+               and cc.min_price = minPrice
+               and cc.min_quantity is null) = 0)
+        then
+            insert into coupon_conditions (takeaway, min_price)
+            values (takeAwayConditionToUse, minPrice)
+            returning conditionid into takeAwayConditionIdToUse;
+            newActions = newActions + 1;
+            call createLogEntry(format('created coupon condition takeaway:"%L" minprice:"%L" id:%L',
+                                       takeAwayConditionToUse, minPrice, takeAwayConditionIdToUse),
+                                logsessiontime,'INFO','process_coupons procedure');
+        else
+            takeAwayConditionIdToUse = (select cc.conditionid
+                                        from coupon_conditions cc
+                                        where cc.takeaway = takeAwayConditionToUse
+                                          and cc.min_price = minPrice
+                                          and cc.min_quantity is null);
+        end if;
+    end if;
+    workingCouponId = (select c.couponid
+                       from coupon c
+                       where c.couponcode like originalCouponcode
+                         and c.action = actionIdToUse
+                         and coalesce(c.condition,-1) = coalesce(takeAwayConditionIdToUse,-1));
+    raise notice 'workingCouponId:% originalCouponcode:% actionIdToUse:% conditionIdToUse:%'
+        ,workingCouponId,originalCouponcode,actionIdToUse,takeAwayConditionIdToUse;
+    if(workingCouponId is null) then
+        --create new coupon and associate with correct action and condition (if applicable)
+        insert into coupon (couponcode, "action", "condition")
+        values (originalCouponcode, actionIdToUse, takeAwayConditionIdToUse)
+        returning couponid into workingCouponId;
+    end if;
+
+    -- create link table entry order - coupon
+    insert into coupon_order (orderid,couponid)
+    values(orderIdToLink,workingCouponId);
+
+    call createLogEntry(format('created coupon with code "%L" actionid:%L conditionid:"%L" couponid:%L',
+                               originalCouponcode, actionIdToUse, takeAwayConditionIdToUse, workingCouponId),
+                        logsessiontime,'INFO','process_coupons procedure');
 exception
     when others then
         GET STACKED DIAGNOSTICS l_context = PG_EXCEPTION_CONTEXT;

--- a/dominos/src/main/java/me/fontys/semester4/dominos/configuration/data/order/OrderImporter.java
+++ b/dominos/src/main/java/me/fontys/semester4/dominos/configuration/data/order/OrderImporter.java
@@ -97,8 +97,6 @@ public class OrderImporter {
         this.storedProcedureExecutor.executeSql("CALL create_customers()", false);
         this.storedProcedureExecutor.executeSql("CALL create_addresses()", false);
         this.storedProcedureExecutor.executeSql("CALL create_orders()", false);
-        LOGGER.info("Process order coupons...");
-        processCouponsProc.Execute();
     }
 
     public void report() {
@@ -111,12 +109,6 @@ public class OrderImporter {
             for (Map.Entry<String, Integer> warning : this.warnings.entrySet()) {
                 LOGGER.warn(String.format("  -> %s : %s", warning.getKey(), warning.getValue()));
             }
-        }
-
-        // get coupons stored procedure logs stored in database
-        for(LogEntry importLogEntry : processCouponsProc.RetrieveLogs())
-        {
-            LOGGER.info(importLogEntry.getMessage());
         }
 
     }

--- a/dominos/src/main/resources/procedures/create_orders.sql
+++ b/dominos/src/main/resources/procedures/create_orders.sql
@@ -44,6 +44,8 @@ BEGIN
                     order_row.delivery_cost, order_row.order_date, 1, 1, LOWER(order_row.delivery_type) = 'afhalen',
                     order_row.total_price, order_row.storeid)
             RETURNING "order".orderid INTO created_order_id;
+            -- process coupon
+            CALL process_coupon(created_order_id,order_row.used_coupon);
 
             INSERT INTO order_product (name, orderid, price, productid, quantity, taxrate)
             VALUES (order_row.product, created_order_id, order_row.product_price, order_row.productid,

--- a/dominos/src/main/resources/procedures/create_orders.sql
+++ b/dominos/src/main/resources/procedures/create_orders.sql
@@ -45,7 +45,9 @@ BEGIN
                     order_row.total_price, order_row.storeid)
             RETURNING "order".orderid INTO created_order_id;
             -- process coupon
-            CALL process_coupon(created_order_id,order_row.used_coupon);
+            IF order_row.used_coupon <> '' THEN
+                CALL process_coupon(created_order_id,order_row.used_coupon);
+            END IF;
 
             INSERT INTO order_product (name, orderid, price, productid, quantity, taxrate)
             VALUES (order_row.product, created_order_id, order_row.product_price, order_row.productid,

--- a/dominos/src/main/resources/procedures/create_orders.sql
+++ b/dominos/src/main/resources/procedures/create_orders.sql
@@ -40,12 +40,12 @@ BEGIN
 
             INSERT INTO "order" (applied_discount, customer, customername, deliverydate, deliveryprice, orderdate,
                                  postalcodeid, streetnr, takeaway, totalprice, store)
-            VALUES (null, order_row.customerid, order_row.customer_name, order_row.delivery_time,
+            VALUES (order_row.coupon_discount, order_row.customerid, order_row.customer_name, order_row.delivery_time,
                     order_row.delivery_cost, order_row.order_date, 1, 1, LOWER(order_row.delivery_type) = 'afhalen',
                     order_row.total_price, order_row.storeid)
             RETURNING "order".orderid INTO created_order_id;
             -- process coupon
-            IF order_row.used_coupon <> '' THEN
+            IF order_row.coupon_discount > 0 THEN
                 CALL process_coupon(created_order_id,order_row.used_coupon);
             END IF;
 


### PR DESCRIPTION
- [x] Created coupons need to be linked to created orders. This is now integrated with the order processing stored procedure.
- [x] Additional check added if coupon discount has coupon code.
- [x] Reduced unnecessary duplicate logging and certain trace logging is now categorised as trace logging.
- [x] Applied discount is taken from the staging table and now filled: it must be calculated by the application. With more time this could be done by a stored procedure as well.